### PR TITLE
Add Observables

### DIFF
--- a/qiskit-sys/build.rs
+++ b/qiskit-sys/build.rs
@@ -126,6 +126,7 @@ fn build_qiskit_from_source() {
         .header(format!("{}/dist/c/include/qiskit.h", repo_dir_str))
         .header(format!("{}/dist/c/include/qiskit/complex.h", repo_dir_str))
         .parse_callbacks(Box::new(CargoCallbacks))
+        .size_t_is_usize(true)
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,4 +71,4 @@
 /// The main qiskit-rs module
 pub mod qiskit;
 
-pub use qiskit::{ClassicalRegister, QiskitError, QuantumCircuit, QuantumRegister};
+pub use qiskit::{ClassicalRegister, QiskitError, QuantumCircuit, QuantumRegister, Observable, Complex64};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,4 +71,6 @@
 /// The main qiskit-rs module
 pub mod qiskit;
 
-pub use qiskit::{ClassicalRegister, QiskitError, QuantumCircuit, QuantumRegister, Observable, Complex64};
+pub use qiskit::{
+    ClassicalRegister, Complex64, Observable, QiskitError, QuantumCircuit, QuantumRegister,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //! #### Clone
 //!
 //! Automatically clones and builds the qiskit c api from source.
-//!       
+//!
 //! <div class="warning">Cloning and building from source is very slow!</div>
 //!
 //! ```bash
@@ -72,5 +72,5 @@
 pub mod qiskit;
 
 pub use qiskit::{
-    ClassicalRegister, Complex64, Observable, QiskitError, QuantumCircuit, QuantumRegister,
+    BitTerm, ClassicalRegister, Complex64, Observable, QiskitError, QuantumCircuit, QuantumRegister,
 };

--- a/src/qiskit.rs
+++ b/src/qiskit.rs
@@ -594,9 +594,12 @@ impl Observable {
         unsafe { qiskit_sys::qk_obs_equal(self.observable, obs.observable) }
     }
     /// Return a string representation of the observable
-    pub fn str(&self) -> &str {
+    pub fn str(&self) -> String {
         let obs_str = unsafe { qiskit_sys::qk_obs_str(self.observable) };
-        unsafe { CStr::from_ptr(obs_str) }.to_str().unwrap()
+        // Clone C string into String, which implements Drop
+        let retval = String::from(unsafe { CStr::from_ptr(obs_str) }.to_str().unwrap());
+        unsafe { qiskit_sys::qk_str_free(obs_str) };
+        retval
     }
 }
 

--- a/src/qiskit.rs
+++ b/src/qiskit.rs
@@ -783,17 +783,27 @@ pub struct Observable {
 /// A complex, double-precision number representation.
 pub type Complex64 = qiskit_sys::QkComplex64;
 
+/// An enum that represents single qubit alphabet terms
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[repr(u8)]
 pub enum BitTerm {
+    /// Pauli X operator
     X = qiskit_sys::QkBitTerm_QkBitTerm_X,
+    /// Pauli Y operator
     Y = qiskit_sys::QkBitTerm_QkBitTerm_Y,
+    /// Pauli Z operator
     Z = qiskit_sys::QkBitTerm_QkBitTerm_Z,
+    /// The projector ∣+⟩⟨+∣∣+⟩⟨+∣ to the positive X eigenstate
     Plus = qiskit_sys::QkBitTerm_QkBitTerm_Plus,
+    /// The projector ∣−⟩⟨−∣∣−⟩⟨−∣ to the negative X eigenstate
     Minus = qiskit_sys::QkBitTerm_QkBitTerm_Minus,
+    /// The projector ∣r⟩⟨r∣∣r⟩⟨r∣ to the positive Y eigenstate
     Right = qiskit_sys::QkBitTerm_QkBitTerm_Right,
+    /// The projector ∣l⟩⟨l∣∣l⟩⟨l∣ to the negative Y eigenstate
     Left = qiskit_sys::QkBitTerm_QkBitTerm_Left,
+    /// The projector ∣0⟩⟨0∣∣0⟩⟨0∣ to the positive Z eigenstate
     Zero = qiskit_sys::QkBitTerm_QkBitTerm_Zero,
+    /// The projector ∣1⟩⟨1∣∣1⟩⟨1∣ to the negative Z eigenstate
     One = qiskit_sys::QkBitTerm_QkBitTerm_One,
 }
 

--- a/src/qiskit.rs
+++ b/src/qiskit.rs
@@ -815,6 +815,7 @@ impl TryFrom<u8> for BitTerm {
     }
 }
 
+/// A list of BitTerms. BitTermList implements a custom iterator.
 pub struct BitTermList(Vec<BitTerm>);
 
 impl BitTermList {
@@ -822,12 +823,15 @@ impl BitTermList {
     pub fn new() -> BitTermList {
         BitTermList(Vec::new())
     }
+    /// Add a BitTerm to a BitTermList
     pub fn add(&mut self, elem: BitTerm) {
         self.0.push(elem);
     }
+    /// Get the length of a BitTermList
     pub fn len(self) -> usize {
         self.0.len()
     }
+    /// Convert a BitTermList to a slice
     pub fn as_slice(&self) -> &[BitTerm] {
         self.0.as_slice()
     }

--- a/src/qiskit.rs
+++ b/src/qiskit.rs
@@ -12,6 +12,7 @@
 use qiskit_sys::{QkParam, qk_circuit_gate};
 use std::collections::BTreeSet;
 use std::ffi::{CStr, CString};
+use std::fmt;
 
 #[derive(PartialEq, Eq, Debug)]
 /// The error enum that enumerates the different error types possible from Qiskit.
@@ -1027,23 +1028,10 @@ impl<'a> Observable {
     pub fn len(&self) -> usize {
         unsafe { qiskit_sys::qk_obs_len(self.observable) }
     }
-    /// Copy the observable
-    pub fn copy(&self) -> Observable {
-        Observable {
-            observable: unsafe { qiskit_sys::qk_obs_copy(self.observable) },
-        }
-    }
+
     /// Compare two observables for equality.
     pub fn equal(&self, obs: &Observable) -> bool {
         unsafe { qiskit_sys::qk_obs_equal(self.observable, obs.observable) }
-    }
-    /// Return a string representation of the observable
-    pub fn str(&self) -> String {
-        let obs_str = unsafe { qiskit_sys::qk_obs_str(self.observable) };
-        // Clone C string into String, which implements Drop
-        let retval = String::from(unsafe { CStr::from_ptr(obs_str) }.to_str().unwrap());
-        unsafe { qiskit_sys::qk_str_free(obs_str) };
-        retval
     }
     /// Apply a new qubit layout to the observable.
     ///
@@ -1059,7 +1047,7 @@ impl<'a> Observable {
     /// let identity = identity.apply_layout(&[10, 9, 8, 7]);
     /// ```
     pub fn apply_layout(&self, layout: &[u32]) -> Observable {
-        let new = self.copy();
+        let new = self.clone();
         let _ = unsafe {
             qiskit_sys::qk_obs_apply_layout(new.observable, layout.as_ptr(), layout.len() as u32)
         };
@@ -1077,9 +1065,38 @@ impl<'a> Observable {
     /// let canonical: Observable = identity.canonicalize(1e-6);
     /// ```
     pub fn canonicalize(&self, tolerance: f64) -> Observable {
-        let new = self.copy();
+        let new = self.clone();
         unsafe { qiskit_sys::qk_obs_canonicalize(new.observable, tolerance) };
         new
+    }
+}
+
+impl fmt::Display for Observable {
+    /// Return a string representation of the observable
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use qiskit_rs::Observable;
+    ///
+    /// let identity = Observable::identity(100);
+    /// println!("{}", identity);
+    /// ```
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let obs_str = unsafe { qiskit_sys::qk_obs_str(self.observable) };
+        // Clone C string into String, which implements Drop
+        let retval = String::from(unsafe { CStr::from_ptr(obs_str) }.to_str().unwrap());
+        unsafe { qiskit_sys::qk_str_free(obs_str) };
+        write!(f, "{}", retval)
+    }
+}
+
+impl Clone for Observable {
+    /// Copy the observable
+    fn clone(&self) -> Observable {
+        Observable {
+            observable: unsafe { qiskit_sys::qk_obs_copy(self.observable) },
+        }
     }
 }
 
@@ -1131,6 +1148,5 @@ mod observable_tests {
 
         let obs_b = Observable::new(num_qubits, &coeffs, &bits, &indices, &boundaries);
         assert!(obs.equal(&obs_b));
-        assert_eq!(obs.str(), obs_b.str());
     }
 }

--- a/src/qiskit.rs
+++ b/src/qiskit.rs
@@ -473,18 +473,48 @@ impl<'a> Iterator for CircuitInstructions<'a> {
     }
 }
 
-fn bitterm_to_qkbitterm(bitterm: char) -> qiskit_sys::QkBitTerm {
-    match bitterm {
-        'X' => qiskit_sys::QkBitTerm_QkBitTerm_X,
-        'Y' => qiskit_sys::QkBitTerm_QkBitTerm_Y,
-        'Z' => qiskit_sys::QkBitTerm_QkBitTerm_Z,
-        '+' => qiskit_sys::QkBitTerm_QkBitTerm_Plus,
-        '-' => qiskit_sys::QkBitTerm_QkBitTerm_Minus,
-        'r' => qiskit_sys::QkBitTerm_QkBitTerm_Right,
-        'l' => qiskit_sys::QkBitTerm_QkBitTerm_Left,
-        '0' => qiskit_sys::QkBitTerm_QkBitTerm_Zero,
-        '1' => qiskit_sys::QkBitTerm_QkBitTerm_One,
-        _ => panic!("Invalid bitterm: {}", bitterm.to_string()),
+#[cfg(test)]
+mod circuit_tests {
+    use super::QuantumCircuit;
+    use std::f64::consts::FRAC_PI_2;
+
+    #[test]
+    fn test_circuit_instructions() {
+        let mut qc = QuantumCircuit::new(100, 100);
+        qc.rz(FRAC_PI_2, 0);
+        qc.sx(0);
+        qc.rz(FRAC_PI_2, 0);
+        for target in 0..100u32 {
+            qc.cx(0, target);
+            qc.measure(target, target);
+        }
+        let res = qc.instructions();
+        let mut target: u32 = 0;
+        for (idx, inst) in res.enumerate() {
+            if idx == 0 || idx == 2 {
+                assert_eq!(inst.name, "rz");
+                assert_eq!(&[0,], inst.qubits);
+                assert_eq!(inst.clbits, &[]);
+                assert_eq!(&[FRAC_PI_2,], inst.params);
+            } else if idx == 1 {
+                assert_eq!(inst.name, "sx");
+                assert_eq!(&[0,], inst.qubits);
+                assert_eq!(inst.clbits, &[]);
+                assert_eq!(inst.params, &[]);
+            } else {
+                let expected_name = if (idx - 3) % 2 == 0 { "cx" } else { "measure" };
+                assert_eq!(expected_name, inst.name);
+                assert_eq!(inst.params, &[]);
+                if expected_name == "measure" {
+                    assert_eq!(inst.qubits, &[target]);
+                    assert_eq!(inst.clbits, &[target]);
+                    target += 1;
+                } else {
+                    assert_eq!(inst.qubits, &[0, target]);
+                    assert_eq!(inst.clbits, &[]);
+                }
+            }
+        }
     }
 }
 
@@ -496,17 +526,78 @@ pub struct Observable {
 /// A complex, double-precision number representation.
 pub type Complex64 = qiskit_sys::QkComplex64;
 
-impl Observable {
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[repr(u8)]
+pub enum BitTerm {
+    X = qiskit_sys::QkBitTerm_QkBitTerm_X,
+    Y = qiskit_sys::QkBitTerm_QkBitTerm_Y,
+    Z = qiskit_sys::QkBitTerm_QkBitTerm_Z,
+    Plus = qiskit_sys::QkBitTerm_QkBitTerm_Plus,
+    Minus = qiskit_sys::QkBitTerm_QkBitTerm_Minus,
+    Right = qiskit_sys::QkBitTerm_QkBitTerm_Right,
+    Left = qiskit_sys::QkBitTerm_QkBitTerm_Left,
+    Zero = qiskit_sys::QkBitTerm_QkBitTerm_Zero,
+    One = qiskit_sys::QkBitTerm_QkBitTerm_One,
+}
+
+impl TryFrom<u8> for BitTerm {
+    type Error = ();
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            qiskit_sys::QkBitTerm_QkBitTerm_X => Ok(BitTerm::X),
+            qiskit_sys::QkBitTerm_QkBitTerm_Y => Ok(BitTerm::Y),
+            qiskit_sys::QkBitTerm_QkBitTerm_Z => Ok(BitTerm::Z),
+            qiskit_sys::QkBitTerm_QkBitTerm_Plus => Ok(BitTerm::Plus),
+            qiskit_sys::QkBitTerm_QkBitTerm_Minus => Ok(BitTerm::Minus),
+            qiskit_sys::QkBitTerm_QkBitTerm_Right => Ok(BitTerm::Right),
+            qiskit_sys::QkBitTerm_QkBitTerm_Left => Ok(BitTerm::Left),
+            qiskit_sys::QkBitTerm_QkBitTerm_Zero => Ok(BitTerm::Zero),
+            qiskit_sys::QkBitTerm_QkBitTerm_One => Ok(BitTerm::One),
+            _ => Err(()),
+        }
+    }
+}
+
+pub struct BitTermList(Vec<BitTerm>);
+
+impl<'a> BitTermList {
+    pub fn new() -> BitTermList {
+        BitTermList(Vec::new())
+    }
+    pub fn add(&mut self, elem: BitTerm) {
+        self.0.push(elem);
+    }
+    pub fn len(self) -> usize {
+        self.0.len()
+    }
+    pub fn as_slice(&self) -> &[BitTerm] {
+        self.0.as_slice()
+    }
+}
+
+impl<'a> FromIterator<BitTerm> for BitTermList {
+    fn from_iter<T: IntoIterator<Item = BitTerm>>(iter: T) -> Self {
+        let mut bit_term_list = BitTermList::new();
+
+        for i in iter {
+            bit_term_list.add(i);
+        }
+
+        bit_term_list
+    }
+}
+
+impl<'a> Observable {
     /// Create a new observable
     ///
     /// # Example
     ///
     /// ```
-    /// use qiskit_rs::{Observable, Complex64};
+    /// use qiskit_rs::{Observable, Complex64, BitTerm};
     //
     /// let num_qubits = 100;
     /// let coeffs = [Complex64{re: 1.0, im: -1.0}, Complex64{re: 1.0, im: -1.0}];
-    /// let bits = ['0', '1', '+', '-'];
+    /// let bits = [BitTerm::Zero, BitTerm::One, BitTerm::Plus, BitTerm::Minus];
     /// let indices = [0, 1, 98, 99];
     /// let boundaries = [0, 2, 4];
     ///
@@ -515,7 +606,7 @@ impl Observable {
     pub fn new(
         num_qubits: u32,
         coeffs: &[Complex64],
-        bit_terms: &[char],
+        bit_terms: &[BitTerm],
         indices: &[u32],
         boundaries: &[usize],
     ) -> Observable {
@@ -524,10 +615,7 @@ impl Observable {
         assert!(coeffs.len() + 1 == boundaries.len());
 
         let mut coeffs: Vec<qiskit_sys::QkComplex64> = Vec::from(coeffs);
-        let mut bit_terms: Vec<u8> = bit_terms
-            .into_iter()
-            .map(|x| bitterm_to_qkbitterm(*x))
-            .collect();
+        let mut bit_terms: Vec<u8> = bit_terms.iter().map(|bitterm| *(bitterm) as u8).collect();
         let mut indices = Vec::from(indices);
         let mut boundaries = Vec::from(boundaries);
         Observable {
@@ -593,11 +681,11 @@ impl Observable {
     /// Get the list of coefficients of an observable
     ///
     /// ```
-    /// use qiskit_rs::{Observable, Complex64};
+    /// use qiskit_rs::{Observable, Complex64, BitTerm};
     ///
     /// let num_qubits = 100;
     /// let coeffs = [Complex64{re: 1.0, im: -1.0}, Complex64{re: 1.0, im: -1.0}];
-    /// let bits = ['0', '1', '+', '-'];
+    /// let bits = [BitTerm::Zero, BitTerm::One, BitTerm::Plus, BitTerm::Minus];
     /// let indices = [0, 1, 98, 99];
     /// let boundaries = [0, 2, 4];
     ///
@@ -616,10 +704,10 @@ impl Observable {
     /// Get the list of indices of an observable
     ///
     /// ```
-    /// use qiskit_rs::{Observable, Complex64};
+    /// use qiskit_rs::{Observable, Complex64, BitTerm};
     /// let num_qubits = 100;
     /// let coeffs = [Complex64{re: 1.0, im: -1.0}, Complex64{re: 1.0, im: -1.0}];
-    /// let bits = ['0', '1', '+', '-'];
+    /// let bits = [BitTerm::Zero, BitTerm::One, BitTerm::Plus, BitTerm::Minus];
     /// let indices = [0, 1, 98, 99];
     /// let boundaries = [0, 2, 4];
     /// let obs = Observable::new(num_qubits, &coeffs, &bits, &indices, &boundaries);
@@ -632,6 +720,51 @@ impl Observable {
         let indices_ptr = unsafe { qiskit_sys::qk_obs_indices(self.observable) };
         let slice = unsafe { std::slice::from_raw_parts(indices_ptr, num_indices) };
         slice.iter()
+    }
+    /// Get the list of boundaries of an observable
+    ///
+    /// ```
+    /// use qiskit_rs::{Observable, Complex64, BitTerm};
+    /// let num_qubits = 100;
+    /// let coeffs = [Complex64{re: 1.0, im: -1.0}, Complex64{re: 1.0, im: -1.0}];
+    /// let bits = [BitTerm::Zero, BitTerm::One, BitTerm::Plus, BitTerm::Minus];
+    /// let indices = [0, 1, 98, 99];
+    /// let boundaries = [0, 2, 4];
+    /// let obs = Observable::new(num_qubits, &coeffs, &bits, &indices, &boundaries);
+    /// for b in obs.boundaries() {
+    ///     print!("Boundary: {}", b);
+    /// }
+    /// ```
+    pub fn boundaries(&self) -> std::slice::Iter<'_, usize> {
+        let num_boundaries: usize = unsafe { qiskit_sys::qk_obs_num_terms(self.observable) } + 1;
+        let boundaries_ptr = unsafe { qiskit_sys::qk_obs_boundaries(self.observable) };
+        let slice = unsafe { std::slice::from_raw_parts(boundaries_ptr, num_boundaries) };
+        slice.iter()
+    }
+    /// Get the list of bitterms of an observable
+    ///
+    /// ```
+    /// use qiskit_rs::{Observable, Complex64, BitTerm};
+    /// let num_qubits = 100;
+    /// let coeffs = [Complex64{re: 1.0, im: -1.0}, Complex64{re: 1.0, im: -1.0}];
+    /// let bits = [BitTerm::Zero, BitTerm::One, BitTerm::Plus, BitTerm::Minus];
+    /// let indices = [0, 1, 98, 99];
+    /// let boundaries = [0, 2, 4];
+    /// let obs = Observable::new(num_qubits, &coeffs, &bits, &indices, &boundaries);
+    /// for b in obs.bit_terms().as_slice().iter() {
+    ///     print!("Bit Terms: {:?}", b);
+    /// }
+    /// ```
+    pub fn bit_terms(&self) -> BitTermList {
+        let num_bit_terms: usize = unsafe { qiskit_sys::qk_obs_len(self.observable) };
+        let bit_terms_ptr = unsafe { qiskit_sys::qk_obs_bit_terms(self.observable) };
+        let slice: &[u8] = unsafe { std::slice::from_raw_parts(bit_terms_ptr, num_bit_terms) };
+        let mut qk_bit_terms = BitTermList::new();
+        for item in slice {
+            let bitterm = BitTerm::try_from(*item).unwrap();
+            qk_bit_terms.add(bitterm);
+        }
+        qk_bit_terms
     }
     /// Get the number of bit terms/indices in the observable.
     pub fn len(&self) -> usize {
@@ -700,98 +833,47 @@ impl Drop for Observable {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{Complex64, Observable, QuantumCircuit};
-    use std::f64::consts::FRAC_PI_2;
+mod observable_tests {
+    use crate::qiskit::BitTerm;
 
+    use super::{Complex64, Observable};
     #[test]
-    fn test_circuit_instructions() {
-        let mut qc = QuantumCircuit::new(100, 100);
-        qc.rz(FRAC_PI_2, 0);
-        qc.sx(0);
-        qc.rz(FRAC_PI_2, 0);
-        for target in 0..100u32 {
-            qc.cx(0, target);
-            qc.measure(target, target);
-        }
-        let res = qc.instructions();
-        let mut target: u32 = 0;
-        for (idx, inst) in res.enumerate() {
-            if idx == 0 || idx == 2 {
-                assert_eq!(inst.name, "rz");
-                assert_eq!(&[0,], inst.qubits);
-                assert_eq!(inst.clbits, &[]);
-                assert_eq!(&[FRAC_PI_2,], inst.params);
-            } else if idx == 1 {
-                assert_eq!(inst.name, "sx");
-                assert_eq!(&[0,], inst.qubits);
-                assert_eq!(inst.clbits, &[]);
-                assert_eq!(inst.params, &[]);
-            } else {
-                let expected_name = if (idx - 3) % 2 == 0 { "cx" } else { "measure" };
-                assert_eq!(expected_name, inst.name);
-                assert_eq!(inst.params, &[]);
-                if expected_name == "measure" {
-                    assert_eq!(inst.qubits, &[target]);
-                    assert_eq!(inst.clbits, &[target]);
-                    target += 1;
-                } else {
-                    assert_eq!(inst.qubits, &[0, target]);
-                    assert_eq!(inst.clbits, &[]);
-                }
-            }
-        }
-    }
-    #[test]
-    fn test_observables() {
+    fn test_new_observable() {
         let num_qubits = 100;
         let coeffs = [
             Complex64 { re: 1.0, im: -1.0 },
             Complex64 { re: 1.0, im: -1.0 },
         ];
-        let bits = ['0', '1', '+', '-'];
+        let bits = [BitTerm::Zero, BitTerm::One, BitTerm::Plus, BitTerm::Minus];
         let indices = [0, 1, 98, 99];
         let boundaries = [0, 2, 4];
 
         let obs = Observable::new(num_qubits, &coeffs, &bits, &indices, &boundaries);
         assert_eq!(obs.num_terms(), 2);
-
-        let obs_b = Observable::new(num_qubits, &coeffs, &bits, &indices, &boundaries);
-        assert!(obs.equal(&obs_b));
-
-        assert_eq!(obs.str(), obs_b.str());
-    }
-    #[test]
-    fn test_iterate_coeffs() {
-        let num_qubits = 100;
-        let coeffs = [
-            Complex64 { re: 1.0, im: -1.0 },
-            Complex64 { re: 1.0, im: -1.0 },
-        ];
-        let bits = ['0', '1', '+', '-'];
-        let indices = [0, 1, 98, 99];
-        let boundaries = [0, 2, 4];
-
-        let obs = Observable::new(num_qubits, &coeffs, &bits, &indices, &boundaries);
-
+        assert_eq!(obs.coeffs().len(), coeffs.len());
         for (i, coef) in obs.coeffs().enumerate() {
             assert_eq!(coef.re, coeffs[i].re);
             assert_eq!(coef.im, coeffs[i].im);
         }
-    }
-    #[test]
-    fn test_iterate_indices() {
-        let num_qubits = 100;
-        let coeffs = [
-            Complex64 { re: 1.0, im: -1.0 },
-            Complex64 { re: 1.0, im: -1.0 },
-        ];
-        let bits = ['0', '1', '+', '-'];
-        let indices = [0, 1, 98, 99];
-        let boundaries = [0, 2, 4];
-        let obs = Observable::new(num_qubits, &coeffs, &bits, &indices, &boundaries);
+        assert_eq!(obs.indices().len(), indices.len());
         for (i, idx) in obs.indices().enumerate() {
             assert_eq!(*idx, indices[i]);
         }
+        assert_eq!(obs.boundaries().len(), boundaries.len());
+        for (i, idx) in obs.boundaries().enumerate() {
+            assert_eq!(*idx, boundaries[i]);
+        }
+
+        assert_eq!(obs.bit_terms().len(), bits.len());
+        for (i, idx) in obs.bit_terms().as_slice().iter().enumerate() {
+            assert_eq!(*idx, bits[i]);
+        }
+
+        assert_eq!(obs.coeffs().len() + 1, obs.boundaries().len());
+        assert_eq!(obs.bit_terms().len(), obs.indices().len());
+
+        let obs_b = Observable::new(num_qubits, &coeffs, &bits, &indices, &boundaries);
+        assert!(obs.equal(&obs_b));
+        assert_eq!(obs.str(), obs_b.str());
     }
 }

--- a/src/qiskit.rs
+++ b/src/qiskit.rs
@@ -816,7 +816,8 @@ impl TryFrom<u8> for BitTerm {
 
 pub struct BitTermList(Vec<BitTerm>);
 
-impl<'a> BitTermList {
+impl BitTermList {
+    /// Create a BitTermList
     pub fn new() -> BitTermList {
         BitTermList(Vec::new())
     }
@@ -831,7 +832,7 @@ impl<'a> BitTermList {
     }
 }
 
-impl<'a> FromIterator<BitTerm> for BitTermList {
+impl FromIterator<BitTerm> for BitTermList {
     fn from_iter<T: IntoIterator<Item = BitTerm>>(iter: T) -> Self {
         let mut bit_term_list = BitTermList::new();
 

--- a/src/qiskit.rs
+++ b/src/qiskit.rs
@@ -775,11 +775,6 @@ mod circuit_tests {
     }
 }
 
-/// An observable over Pauli bases that stores its data in a qubit-sparse format.
-pub struct Observable {
-    observable: *mut qiskit_sys::QkObs,
-}
-
 /// A complex, double-precision number representation.
 pub type Complex64 = qiskit_sys::QkComplex64;
 
@@ -859,7 +854,12 @@ impl FromIterator<BitTerm> for BitTermList {
     }
 }
 
-impl<'a> Observable {
+/// An observable over Pauli bases that stores its data in a qubit-sparse format.
+pub struct Observable {
+    observable: *mut qiskit_sys::QkObs,
+}
+
+impl Observable {
     /// Create a new observable
     ///
     /// # Example


### PR DESCRIPTION
Closes #2 

## Progress

- [x] [qk_obs_zero](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_zero)
- [x] [qk_obs_identity](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_identity)
- [x] [qk_obs_new](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_new)
- [x] [qk_obs_free](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_free)
- [ ] ~[qk_obs_add_term](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_add_term)~ (Not in-scope of this PR)
- [ ] ~[qk_obs_term](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_term)~ (Not in-scope of this PR)
- [x] [qk_obs_num_terms](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_num_terms)
- [x] [qk_obs_num_qubits](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_num_qubits)
- [x] [qk_obs_len](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_len)
- [x] [qk_obs_coeffs](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_coeffs)
- [x] [qk_obs_indices](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_indices)
- [x] [qk_obs_boundaries](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_boundaries)
- [x] [qk_obs_bit_terms](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_bit_terms)
- [x] [qk_obs_multiply](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_multiply)
- [x] [qk_obs_add](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_add)
- [x] [qk_obs_compose](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_compose)
- [x] [qk_obs_compose_map](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_compose_map)
- [x] [qk_obs_apply_layout](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_apply_layout)
- [x] [qk_obs_canonicalize](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_canonicalize)
- [x] [qk_obs_copy](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_copy)
- [x] [qk_obs_equal](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_equal)
- [x] [qk_obs_str](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_str)
- [x] [qk_str_free](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_str_free)
- [ ] ~[qk_obs_to_python](https://quantum.cloud.ibm.com/docs/en/api/qiskit-c/qk-obs#qk_obs_to_python)~