### PR TITLE
Reset repository after building

### DIFF
--- a/qiskit-sys/build.rs
+++ b/qiskit-sys/build.rs
@@ -79,6 +79,9 @@ fn clone_qiskit(source_path: &Path) {
                     let (obj, _) = repo
                         .revparse_ext(refname)
                         .unwrap_or_else(|_| panic!("{} not found in repo", refname));
+                    // Reset the repository in case of any untracked changes
+                    repo.reset(&obj, git2::ResetType::Soft, None)
+                        .expect("Error resetting repository.");
                     repo.checkout_tree(&obj, None)
                         .unwrap_or_else(|_| panic!("failed to checkout {}", refname));
                 }


### PR DESCRIPTION
The following commit aims to resolve an issue that results in consecutive cargo builds to fail due to the repository already existing and having certain uncommitted changes before checkout. By soft resetting the repo before checking out, the builds don't fail and doesn't require the user to invoke `cargo clean` before re-building.