### PR TITLE
Chore: Suppress additional `bindgen` warnings

### DIFF
--- a/qiskit-sys/src/lib.rs
+++ b/qiskit-sys/src/lib.rs
@@ -12,7 +12,8 @@
 
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
-
+#![allow(non_snake_case)]
+#![allow(improper_ctypes)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[cfg(test)]


### PR DESCRIPTION
The following commit suppresses several warnings coming from generated bindgen files.