### PR TITLE
Update to Qiskit 2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "qiskit-sys"
-version = "2.2.3"
+version = "2.3.0"
 dependencies = [
  "bindgen",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ test = true
 doctest = true
 
 [dependencies]
-qiskit-sys = { path = "qiskit-sys", version="2.2.3" }
+qiskit-sys = { path = "qiskit-sys", version="2.3.0" }

--- a/qiskit-sys/Cargo.toml
+++ b/qiskit-sys/Cargo.toml
@@ -5,7 +5,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 description = "Raw bindings to libqiskit"
-version = "2.2.3"
+version = "2.3.0"
 
 [dependencies]
 


### PR DESCRIPTION
The following commits update the package to use Qiskit 2.3 instead of Qiskit 2.2.3 to take advantage of the new features of the C API. As we have still not developed many new features it should make sense for us to seamlessly update to Qiskit 2.3 and use it as the base of all upcoming features.