### PR TITLE
Draft: Add a `python_binding` feature

### DIFF
--- a/qiskit-sys/Cargo.toml
+++ b/qiskit-sys/Cargo.toml
@@ -8,6 +8,11 @@ description = "Raw bindings to libqiskit"
 version = "2.3.0"
 
 [dependencies]
+pyo3 = { version = "0.27", features = ["abi3-py310"], optional = true}
+
+[features]
+default = []
+python_binding = ["dep:pyo3"]
 
 [build-dependencies]
 bindgen = "0.72.0"


### PR DESCRIPTION
This is a work-in-progress on which I would like to get some eyes.
The idea is the following:

Add an optional feature (`python_binding`) to the `qiskit-sys` crate which will switch the Qiskit library target from the pure C-lib (`libqiskit.so`) to the Python-acceleration crate (which also includes the C FFI).

As you can see, this required some additional tweaks to the `bindgen::Builder` in order to get working. In particular, it was necessary to manually whitelist the Qiskit C API components while ensuring no additional Python bindings are being generated.

In the current form, this update works iff one also adds a symlink of the Qiskit Python acceleration lib (`_accelerate...so`) to `libqiskit.so` because this build script will otherwise not find the library correctly. This also means that this currently only works with the `path` installation method.

Here are some concrete questions:
1. can we figure out a way to detect/predict the correct library filename to link against? If not, can Qiskit consider creating such a link as part of their build routine?
2. Is there a cleaner way to generate the headers for only the Qiskit C API without requiring manual whitelisting while also avoiding generating bindings for all Python functions?