### PR TITLE
Add "transpile" function

### DIFF
--- a/src/circuit/quantum_circuit.rs
+++ b/src/circuit/quantum_circuit.rs
@@ -50,7 +50,7 @@ impl QuantumCircuit {
     /// let mut qc = QuantumCircuit::new(10, 10);
     /// let n = qc.num_qubits();
     /// ```
-    pub fn num_qubits(&mut self) -> u32 {
+    pub fn num_qubits(&self) -> u32 {
         unsafe { qiskit_sys::qk_circuit_num_qubits(self.circuit) }
     }
     /// Return the number of classical bits in a QuantumCircuit.

--- a/src/circuit/quantum_circuit.rs
+++ b/src/circuit/quantum_circuit.rs
@@ -20,7 +20,7 @@ use super::registers::{ClassicalRegister, QuantumRegister};
 
 /// The core representation of a quantum circuit.
 pub struct QuantumCircuit {
-    circuit: *mut qiskit_sys::QkCircuit,
+    pub(crate) circuit: *mut qiskit_sys::QkCircuit,
 }
 
 impl QuantumCircuit {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,10 @@ pub mod circuit;
 mod qiskit;
 /// The main module for quantum information tools.
 pub mod quantum_info;
+/// Quantum circuit transpiler module.
+pub mod transpiler;
 
 pub use circuit::{ClassicalRegister, QuantumCircuit, QuantumRegister};
 pub use qiskit::{Complex64, QiskitError};
 pub use quantum_info::{BitTerm, Observable};
+pub use transpiler::transpile;

--- a/src/transpiler/mod.rs
+++ b/src/transpiler/mod.rs
@@ -1,0 +1,17 @@
+// This code is part of Qiskit Rust bindings.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+mod target;
+mod transpiler;
+
+pub use target::*;
+pub use transpiler::*;

--- a/src/transpiler/target.rs
+++ b/src/transpiler/target.rs
@@ -11,7 +11,7 @@
 // that they have been altered from the originals.
 
 pub struct Target {
-    pub target: *mut qiskit_sys::QkTarget,
+    pub(crate) target: *mut qiskit_sys::QkTarget,
 }
 
 impl Target {

--- a/src/transpiler/target.rs
+++ b/src/transpiler/target.rs
@@ -1,0 +1,22 @@
+// This code is part of Qiskit Rust bindings.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+pub struct Target {
+    pub target: *mut qiskit_sys::QkTarget,
+}
+
+impl Target {
+    pub fn new(num_qubits: u32) -> Target {
+        let target = unsafe { qiskit_sys::qk_target_new(num_qubits) };
+        Target { target: target }
+    }
+}

--- a/src/transpiler/target.rs
+++ b/src/transpiler/target.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+/// A mapping of instructions and properties representing the particular constraints of a backend.
 pub struct Target {
     pub(crate) target: *mut qiskit_sys::QkTarget,
 }

--- a/src/transpiler/target.rs
+++ b/src/transpiler/target.rs
@@ -20,3 +20,9 @@ impl Target {
         Target { target: target }
     }
 }
+
+impl Drop for Target {
+    fn drop(&mut self) {
+        unsafe { qiskit_sys::qk_target_free(self.target) };
+    }
+}

--- a/src/transpiler/transpiler.rs
+++ b/src/transpiler/transpiler.rs
@@ -37,7 +37,7 @@ pub fn transpile(
         qiskit_sys::qk_transpile(
             qc.circuit,
             target.target,
-            &options,
+            &options.options,
             &mut qk_transpile_result,
             error,
         )

--- a/src/transpiler/transpiler.rs
+++ b/src/transpiler/transpiler.rs
@@ -21,7 +21,11 @@ pub struct Layout {
     pub layout: *mut qiskit_sys::QkTranspileLayout,
 }
 
-pub type TranspilerOptions = qiskit_sys::QkTranspileOptions;
+impl Drop for Layout {
+    fn drop(&mut self) {
+        unsafe { qiskit_sys::qk_transpile_layout_free(self.layout) };
+    }
+}
 
 pub fn transpile(
     qc: QuantumCircuit,

--- a/src/transpiler/transpiler.rs
+++ b/src/transpiler/transpiler.rs
@@ -12,10 +12,10 @@
 
 use std::ffi::CStr;
 
-use qiskit_sys::QkTranspileResult;
+use qiskit_sys::{QkTranspileResult, qk_transpiler_default_options};
 
 use crate::QuantumCircuit;
-use crate::Target;
+use crate::transpiler::Target;
 
 pub struct Layout {
     pub layout: *mut qiskit_sys::QkTranspileLayout,
@@ -27,6 +27,48 @@ impl Drop for Layout {
     }
 }
 
+/// Specify options for the transpiler function
+pub struct TranspilerOptions {
+    options: qiskit_sys::QkTranspileOptions,
+}
+
+impl TranspilerOptions {
+    /// Use default transpiler options
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use qiskit_rs::{QuantumCircuit};
+    /// use qiskit_rs::transpiler::{transpile, TranspilerOptions, Target};
+    ///
+    /// let qc = QuantumCircuit::new(2, 2);
+    /// let options = TranspilerOptions::default();
+    /// let target = Target::new(2);
+    /// transpile(qc, target, options);
+    /// ```
+    pub fn default() -> TranspilerOptions {
+        TranspilerOptions {
+            options: unsafe { qk_transpiler_default_options() },
+        }
+    }
+}
+
+/// Transpile a single circuit.
+///
+/// The Qiskit transpiler is a quantum circuit compiler that rewrites a given input
+/// circuit to match the constraints of a QPU and optimizes the circuit for execution.
+///
+/// # Example
+///
+/// ```
+/// use qiskit_rs::{QuantumCircuit};
+/// use qiskit_rs::transpiler::{transpile, TranspilerOptions, Target};
+///
+/// let qc = QuantumCircuit::new(2, 2);
+/// let options = TranspilerOptions::default();
+/// let target = Target::new(2);
+/// transpile(qc, target, options);
+/// ```
 pub fn transpile(
     qc: QuantumCircuit,
     target: Target,

--- a/src/transpiler/transpiler.rs
+++ b/src/transpiler/transpiler.rs
@@ -1,0 +1,59 @@
+// This code is part of Qiskit Rust bindings.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use std::ffi::CStr;
+
+use qiskit_sys::QkTranspileResult;
+
+use crate::QuantumCircuit;
+use crate::Target;
+
+pub struct Layout {
+    pub layout: *mut qiskit_sys::QkTranspileLayout,
+}
+
+pub type TranspilerOptions = qiskit_sys::QkTranspileOptions;
+
+pub fn transpile(
+    qc: QuantumCircuit,
+    target: Target,
+    options: TranspilerOptions,
+) -> (QuantumCircuit, Layout) {
+    let mut qk_transpile_result: qiskit_sys::QkTranspileResult = QkTranspileResult {
+        circuit: std::ptr::null_mut(),
+        layout: std::ptr::null_mut(),
+    };
+    let mut error: *mut *mut i8 = std::ptr::null_mut();
+    let error_code = unsafe {
+        qiskit_sys::qk_transpile(
+            qc.circuit,
+            target.target,
+            &options,
+            &mut qk_transpile_result,
+            error,
+        )
+    };
+    if error_code != qiskit_sys::QkExitCode_QkExitCode_Success {
+        let error_str = unsafe { *error };
+        let error_msg = unsafe { CStr::from_ptr(error_str) };
+        let error_msg: &str = error_msg.to_str().unwrap();
+        panic!("ERROR: {}", error_msg);
+    }
+    (
+        QuantumCircuit {
+            circuit: qk_transpile_result.circuit,
+        },
+        Layout {
+            layout: qk_transpile_result.layout,
+        },
+    )
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,2 @@
+mod transpiler;
+

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,2 +1,1 @@
 mod transpiler;
-

--- a/tests/transpiler/mod.rs
+++ b/tests/transpiler/mod.rs
@@ -1,0 +1,1 @@
+mod test_transpiler;

--- a/tests/transpiler/test_transpiler.rs
+++ b/tests/transpiler/test_transpiler.rs
@@ -10,17 +10,14 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use qiskit_rs::{QuantumCircuit, Target, transpile, transpiler::TranspilerOptions};
+use qiskit_rs::QuantumCircuit;
+use qiskit_rs::transpiler::{Target, TranspilerOptions, transpile};
 
 #[test]
 fn test_transpile() {
     let qc = QuantumCircuit::new(2, 2);
-    let options = TranspilerOptions {
-        optimization_level: 0,
-        seed: 0,
-        approximation_degree: 0.0,
-    };
+    let options = TranspilerOptions::default();
     let target = Target::new(2);
-    let (isa_circuit, layout) = transpile(qc, target, options);
+    let (isa_circuit, _) = transpile(qc, target, options);
     assert_eq!(isa_circuit.num_qubits(), 2);
 }

--- a/tests/transpiler/test_transpiler.rs
+++ b/tests/transpiler/test_transpiler.rs
@@ -1,0 +1,26 @@
+// This code is part of Qiskit Rust bindings.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use qiskit_rs::{QuantumCircuit, Target, transpile, transpiler::TranspilerOptions};
+
+#[test]
+fn test_transpile() {
+    let qc = QuantumCircuit::new(2, 2);
+    let options = TranspilerOptions {
+        optimization_level: 0,
+        seed: 0,
+        approximation_degree: 0.0,
+    };
+    let target = Target::new(2);
+    let (isa_circuit, layout) = transpile(qc, target, options);
+    assert_eq!(isa_circuit.num_qubits(), 2);
+}


### PR DESCRIPTION
Closes https://github.com/Qiskit/qiskit-rs/issues/3

Creates a simple `transpile` function using `qk_transpile` with room to expand features down the line.

### Example

```
let qc = QuantumCircuit::new(2, 2);
let options = TranspilerOptions::default();
let target = Target::new(2);
let (isa_circuit, layout) = transpile(qc, target, options);
```