### PR TITLE
Add Qiskit repository as a submodule.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - name: Rust fmt
       run: cargo fmt --all --check
     - name: Clippy

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "qiskit"]
+	path = qiskit-sys/qiskit
+	url = https://github.com/Qiskit/qiskit.git

--- a/qiskit-sys/build.rs
+++ b/qiskit-sys/build.rs
@@ -64,11 +64,15 @@ fn build_qiskit(source_path: &Path, new_path: &Path) {
 
     let new_to_dist = new_path.join("dist");
 
+    // We must copy the generated dynamic library and header files
+    // to our output folder so it is automatically included in the
+    // rpath and cargo is able to correctly link to the dynamic
+    // library and the header files.
     Command::new("cp")
-        .current_dir(source_path)
+        .current_dir(source_path.join("dist"))
         .args([
             "-r",
-            "./dist",
+            ".",
             new_to_dist
                 .to_str()
                 .expect("Path should be convertible to string"),
@@ -94,7 +98,7 @@ fn build_qiskit_from_source() {
     let new_path = std::env::var("OUT_DIR").expect("OUT_DIR env variable should have been set.");
     let new_path = Path::new(&new_path);
 
-    build_qiskit(source_path, &new_path);
+    build_qiskit(source_path, new_path);
     let repo_dir_str = new_path.to_str().unwrap();
     generate_bindings(repo_dir_str);
 }

--- a/qiskit-sys/build.rs
+++ b/qiskit-sys/build.rs
@@ -55,12 +55,26 @@ fn check_installation_method() -> InstallMethod {
     }
 }
 
-fn build_qiskit(source_path: &Path) {
-    let _ = Command::new("make")
+fn build_qiskit(source_path: &Path, new_path: &Path) {
+    Command::new("make")
         .current_dir(source_path)
         .arg("c")
         .status()
         .expect("Dynamically linked library generation failed");
+
+    let new_to_dist = new_path.join("dist");
+
+    Command::new("cp")
+        .current_dir(source_path)
+        .args([
+            "-r",
+            "./dist",
+            new_to_dist
+                .to_str()
+                .expect("Path should be convertible to string"),
+        ])
+        .status()
+        .expect("Source path for c files should exist");
 }
 
 fn build_qiskit_from_source() {
@@ -76,8 +90,12 @@ fn build_qiskit_from_source() {
         Err(e) => panic!("{e:?}"),
     }
 
-    build_qiskit(source_path);
-    let repo_dir_str = source_path.to_str().unwrap();
+    // Path to which we will copy the generated c files.
+    let new_path = std::env::var("OUT_DIR").expect("OUT_DIR env variable should have been set.");
+    let new_path = Path::new(&new_path);
+
+    build_qiskit(source_path, &new_path);
+    let repo_dir_str = new_path.to_str().unwrap();
     generate_bindings(repo_dir_str);
 }
 

--- a/qiskit-sys/build.rs
+++ b/qiskit-sys/build.rs
@@ -55,42 +55,6 @@ fn check_installation_method() -> InstallMethod {
     }
 }
 
-fn clone_qiskit(source_path: &Path) {
-    let url = "https://github.com/Qiskit/qiskit.git";
-    match git2::Repository::clone(url, source_path) {
-        Ok(repo) => {
-            println!("Repository successfully cloned");
-            let refname = env!("CARGO_PKG_VERSION");
-            if !refname.contains("dev") {
-                let (obj, _) = repo
-                    .revparse_ext(refname)
-                    .unwrap_or_else(|_| panic!("{} not found in repo", refname));
-                repo.checkout_tree(&obj, None)
-                    .unwrap_or_else(|_| panic!("failed to checkout {}", refname));
-            }
-        }
-        Err(e) => match e.code() {
-            git2::ErrorCode::Exists => {
-                println!("Repository already exists");
-                let refname = env!("CARGO_PKG_VERSION");
-                if !refname.contains("dev") {
-                    let repo = git2::Repository::open(source_path)
-                        .unwrap_or_else(|_| panic!("Invalid repo at {:?}", source_path));
-                    let (obj, _) = repo
-                        .revparse_ext(refname)
-                        .unwrap_or_else(|_| panic!("{} not found in repo", refname));
-                    // Reset the repository in case of any untracked changes
-                    repo.reset(&obj, git2::ResetType::Soft, None)
-                        .expect("Error resetting repository.");
-                    repo.checkout_tree(&obj, None)
-                        .unwrap_or_else(|_| panic!("failed to checkout {}", refname));
-                }
-            }
-            _ => panic!("Git clone failed: {e:?}"),
-        },
-    }
-}
-
 fn build_qiskit(source_path: &Path) {
     let _ = Command::new("make")
         .current_dir(source_path)
@@ -100,11 +64,9 @@ fn build_qiskit(source_path: &Path) {
 }
 
 fn build_qiskit_from_source() {
-    let out_dir = std::env::var("OUT_DIR").unwrap();
-    let source_path = Path::new(&out_dir).join("qiskit_c_lib");
+    let out_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let source_path = Path::new(&out_dir).join("qiskit");
     let source_path = source_path.as_path();
-
-    clone_qiskit(source_path);
 
     match source_path.try_exists() {
         Ok(b) => match b {


### PR DESCRIPTION
The following commits aim to take advantage of the submodule architecture present in git and leverage it in our build process.

### Summary
This pull request performs the following:
- Add Qiskit as a submodule using the current tag that `qiskit` builds against (2.4.0).
- Update the build script to no longer need to checkout the repository and use the submodule when building.