### PR TITLE
Bump to Qiskit 2.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "qiskit-sys"
-version = "2.4.0"
+version = "2.5.1"
 dependencies = [
  "bindgen",
  "git2",

--- a/qiskit-sys/Cargo.toml
+++ b/qiskit-sys/Cargo.toml
@@ -5,7 +5,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 description = "Raw bindings to libqiskit"
-version = "2.4.0"
+version = "2.5.1"
 
 [dependencies]
 


### PR DESCRIPTION
The following commits bump `qiskit-sys`, as well as the `qiskit` submodule tag, to  version `2.5.1`.